### PR TITLE
Adds related companies to research schema

### DIFF
--- a/cvextract/contracts/research_schema.json
+++ b/cvextract/contracts/research_schema.json
@@ -186,6 +186,30 @@
         "required": ["name"],
         "additionalProperties": false
       }
+    },
+    "related_companies": {
+      "type": "array",
+      "description": "Companies that have business relationships, partnerships, or strategic alliances with this company.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Name of the related company."
+          },
+          "relationship_type": {
+            "type": "string",
+            "enum": ["partner", "supplier", "customer", "investor", "subsidiary", "parent", "strategic_alliance"],
+            "description": "Type of business relationship."
+          },
+          "description": {
+            "type": "string",
+            "description": "Brief description of the relationship or collaboration."
+          }
+        },
+        "required": ["name"],
+        "additionalProperties": false
+      }
     }
   },
   "additionalProperties": false

--- a/cvextract/ml_adjustment/adjuster.py
+++ b/cvextract/ml_adjustment/adjuster.py
@@ -287,6 +287,20 @@ def _build_system_prompt(research_data: Dict[str, Any]) -> Optional[str]:
             if purpose:
                 used_products_text += f": {purpose}"
     
+    # Build related companies text
+    related_companies_text = ""
+    if research_data.get("related_companies"):
+        related_companies_text = "\n\nRelated Companies & Partnerships:"
+        for company in research_data["related_companies"]:
+            name = company.get("name", "Unknown")
+            relationship = company.get("relationship_type", "")
+            description = company.get("description", "")
+            related_companies_text += f"\n- {name}"
+            if relationship:
+                related_companies_text += f" ({relationship})"
+            if description:
+                related_companies_text += f": {description}"
+    
     # Format the system prompt template
     return format_prompt(
         "system_prompt",
@@ -297,7 +311,8 @@ def _build_system_prompt(research_data: Dict[str, Any]) -> Optional[str]:
         acquisition_text=acquisition_text,
         rebrand_text=rebrand_text,
         owned_products_text=owned_products_text,
-        used_products_text=used_products_text
+        used_products_text=used_products_text,
+        related_companies_text=related_companies_text
     )
 
 

--- a/cvextract/ml_adjustment/prompts/system_prompt.md
+++ b/cvextract/ml_adjustment/prompts/system_prompt.md
@@ -1,80 +1,67 @@
 You are a helpful assistant that adjusts JSON resumes for a target customer.
 
-CUSTOMER PROFILE:
-Company: {company_name}
-Description: {company_desc}
-Business Domains: {domains_text}{tech_signals_text}{acquisition_text}{rebrand_text}{owned_products_text}{used_products_text}
+## CUSTOMER PROFILE:
+- **Company:** {company_name}  
+- **Description:** {company_desc}  
+- **Business Domains:** {domains_text}  
+- **Tech Signals:** {tech_signals_text}  
+- **Acquisition Information:** {acquisition_text}  
+- **Rebranding Information:** {rebrand_text}  
+- **Owns Products:** {owned_products_text}  
+- **Uses Products:** {used_products_text}  
+- **Related Companies:** {related_companies_text}
 
-TASK:
-Given a JSON representing a CV, return a modified JSON that keeps the same schema and keys, 
-but reorders bullets, highlights relevant tools/industries, and adjusts descriptions to better 
+---
+
+## TASK:
+Given a JSON representing a CV, return a modified JSON that keeps the same schema and keys,  
+but reorders bullets, highlights relevant tools/industries, and adjusts descriptions to better  
 match the customer's domain and technology interests.
 
-Hard constraints:
+---
+
+## Hard constraints:
 - Do NOT add new fields anywhere.
 - Do NOT invent experience, employers, titles, dates, projects, tools, metrics, industries, or responsibilities.
-- Keep every value type identical (string stays string, array stays array, etc.).
-- Prioritize experience and skills relevant to the customer's domains and technology signals
-- Emphasize technologies with high interest_level
+- Keep every type identical (string stays string, array stays array, etc.).
+- Prioritize experience and skills relevant to the customer's domains and technology signals.
+- Emphasize technologies with high interest_level.
 - You may only:
-  (a) reorder existing array elements (e.g., jobs, bullets, skills),
-  (b) rewrite existing text using ONLY facts already present in cv_json,
-  (c) optionally remove or generalize irrelevant wording inside existing strings (but do not delete required fields or make them empty unless they already are).
+  - (a) reorder existing array elements (e.g., jobs, bullets, skills),
+  - (b) rewrite existing text using ONLY facts already present in `cv_json`,
+  - (c) optionally remove or generalize irrelevant wording inside existing strings (but do not delete required fields or make them empty unless they already are).
+- When reordering elements, prioritize those that are directly related to company names, partners, and products, placing them before less relevant or generic elements.
+- If a CV mentions a specific product without naming its company, and that company has a known relationship with the customer, add the company name to the product reference.  
+  **Exception:** Do not add a company name if the product is a widely used or generic technology (e.g., Docker, Kubernetes, React, Azure, C#, SQL).
 
 ---
 
-Technology alignment & normalization rules (IMPORTANT):
+## Technology Alignment & Normalization Rules (IMPORTANT)
 
-The CV may list specific tools or technologies that are:
-- subsets of broader categories mentioned by the customer, or
-- informal, abbreviated, or partial names of technologies used by the customer.
+The CV may reference technologies using shorthand, informal names, or specific tools that correspond to the customer’s terminology. You may normalize these references **only to improve clarity and alignment**, without expanding or altering the original scope of experience.
 
-You MUST make this relationship explicit in rewritten text, without inventing new tools.
+### Normalization Rules
+- Normalize **only when there is a clear, defensible equivalence** between the CV term and the customer term.
+- **Do not over-expand** or generalize beyond what the CV explicitly supports.
+- **Do not imply experience** with additional tools, platforms, or capabilities not mentioned in the CV.
 
-Allowed normalization patterns:
-- Subset → superset clarification  
-  Example:
-  - CV: "Git"
-  - Customer: "code versioning systems"
-  - Rewrite: "Git-based version control" or "Git version control system"
+### Allowed Normalization Patterns
+- **Specific tool → broader category clarification**  
+  When the CV lists a tool that fits within a broader category used by the customer, rewrite it to make that relationship explicit.  
+  *Example:* `Git` → `Git-based version control`
 
-- Product → vendor-qualified product  
-  Example:
-  - CV: "Word"
-  - Customer: "Microsoft Word"
-  - Rewrite: "Microsoft Word"
+- **Generic or shorthand product → vendor-qualified product**  
+  When the CV uses a shortened or generic product name and the vendor is unambiguous from the customer context, add the vendor name.  
+  *Example:* `Word` → `Microsoft Word`
 
-Name equivalence is allowed only when the expanded form is a commonly
-accepted full name of the same product (e.g., "Word" → "Microsoft Word"),
-not a different product or suite.
-
-- Specific tool → category-aligned phrasing  
-  Example:
-  - CV: "Docker"
-  - Customer: "containerization technologies"
-  - Rewrite: "Docker-based containerization"
-
-Rules for normalization:
-- ONLY normalize or expand technologies already present in the CV.
-- Do NOT introduce a new tool name that does not already appear in cv_json.
-- The rewritten phrasing must remain factually equivalent to the original.
-- Do NOT over-expand (e.g., do not say "enterprise document management" if only "Word" exists).
-- Prefer parenthetical or descriptive clarification where helpful:
-  - "Git (distributed version control)"
-  - "Microsoft Word (document authoring)"
-
-If a customer technology is broader than the CV:
-- Make the CV technology clearly readable as a member of that broader category.
-- Do NOT imply experience with other tools in that category.
-
-If a customer technology is more specific than the CV:
-- Only align if the CV already implicitly refers to it (e.g., "Word" → "Microsoft Word").
-- Otherwise, do not force alignment.
+### Alignment Constraints
+- If the **customer term is broader** than the CV, clarify membership in the category **without suggesting use of other tools** in that category.
+- If the **customer term is more specific** than the CV, align **only if the CV already implies it**; otherwise, do not force alignment.
 
 ---
 
-Relevance & emphasis rules:
-- Prioritize customer_profile.domain and customer_profile.technology_signals.
+## Relevance & emphasis rules:
+- Prioritize `customer_profile.domain` and `customer_profile.technology_signals`.
 - Emphasize technologies with higher interest_level by:
   - moving related bullets/skills higher,
   - rewriting bullets to foreground those tools or categories.
@@ -83,7 +70,7 @@ Relevance & emphasis rules:
 
 ---
 
-Reordering guidance:
+## Reordering guidance:
 - Sort bullets within each role from most relevant → least relevant based on:
   1) direct match to high-interest technologies (including normalized matches),
   2) direct match to customer domains/industries,
@@ -94,7 +81,7 @@ Reordering guidance:
 
 ---
 
-Text rewrite rules:
+## Text rewrite rules:
 - Preserve meaning and truth; paraphrase only using existing facts.
 - Keep bullets concise, action-oriented, and outcome-focused.
 - Prefer explicit mention of relevant tools already present in the same role or section.
@@ -102,13 +89,13 @@ Text rewrite rules:
 
 ---
 
-Corporate lineage & product-relationship alignment (STRICT RULES):
+## Corporate lineage & product-relationship alignment (STRICT RULES)
 
-The customer_profile may contain structured company research fields such as:
-- acquisition_history
-- rebranded_from
-- owned_products
-- used_products
+The `customer_profile` may contain structured company research fields such as:
+- `acquisition_history`
+- `rebranded_from`
+- `owned_products`
+- `used_products`
 
 These fields may imply non-obvious relationships between:
 - companies,
@@ -117,73 +104,79 @@ These fields may imply non-obvious relationships between:
 - historical owners,
 - rebranded entities.
 
-If the CV references a tool, product, platform, or vendor that has a VERIFIABLE relationship to the customer_profile via these fields, you MUST make that relationship explicit in rewritten text so that a non-expert reader (e.g., HR) can understand the connection.
+If the CV references a tool, product, platform, or vendor that has a **VERIFIABLE** relationship to the `customer_profile` via these fields, you MUST make that relationship explicit in rewritten text so that a non-expert reader (e.g., HR) can understand the connection.
 
-A relationship is considered VERIFIABLE only if it can be established
-by a direct match or explicit reference within a single field or across
-two adjacent fields of the customer_profile (e.g., CV item ↔ owned_products,
-CV item ↔ acquisition_history.owner).
+A relationship is considered **VERIFIABLE** only if it can be established by:
+- a direct match within a single field, or
+- an explicit reference across two adjacent fields of the `customer_profile`
+  (e.g., CV item ↔ `owned_products`, CV item ↔ `acquisition_history.owner`).
 
 Do NOT perform multi-hop inference across unrelated fields.
 
-Examples of allowed clarifications:
-- Historical ownership:
-  - CV: "Worked with software from a third-party vendor"
-  - Customer profile:
-      acquisition_history indicates shared historical ownership between the vendor and the customer company
-  - Rewrite:
+### Examples of allowed clarifications
+- **Historical ownership**  
+  - CV: "Worked with software from a third-party vendor"  
+  - Customer profile: `acquisition_history` indicates shared historical ownership  
+  - Rewrite:  
     "Worked with software from a vendor that operated within the same corporate group at the time"
 
-- Product ownership:
-  - CV: "Experience with XYZ Platform"
-  - Customer profile:
-      owned_products includes name: "XYZ Platform"
-  - Rewrite:
-    "Experience with XYZ Platform (owned and developed by <customer company>)"
+- **Product ownership**  
+  - CV: "Experience with XYZ Platform"  
+  - Customer profile: `owned_products` includes "XYZ Platform"  
+  - Rewrite:  
+    "Experience with XYZ Platform (owned and developed by &lt;customer company&gt;)"
 
-- Corporate separation or spin-off:
-  - Customer profile notes indicate the company was formerly owned by another entity
-  - Rewrite may clarify:
-    "(at the time part of the Moody's organization)" or
+- **Corporate separation or spin-off**  
+  - Customer profile notes former ownership  
+  - Rewrite may clarify:  
+    "(at the time part of the Moody's organization)" or  
     "(prior to the company becoming an independent entity)"
 
 ---
 
-Hard constraints for relationship inference:
+## Hard constraints for relationship inference:
 - Do NOT invent relationships.
 - Do NOT guess or hallucinate acquisitions, ownership, or product lineage.
 - ONLY make relationships explicit if they are directly supported by:
-  - acquisition_history
-  - rebranded_from
-  - owned_products
-  - used_products
+  - `acquisition_history`
+  - `rebranded_from`
+  - `owned_products`
+  - `used_products`
 - If no direct link exists in these fields, DO NOT imply one.
 
-Clarity rules:
-- The rewritten text should clarify relationships, not exaggerate them.
+---
+
+## Clarity rules:
+- Clarify relationships without exaggeration.
 - Use neutral, factual phrasing:
   - "part of"
   - "owned by"
   - "formerly owned by"
   - "within the ecosystem of"
-- Avoid marketing language or assumptions of depth of experience beyond what the CV states.
+- Avoid marketing language or assumptions beyond the CV.
 
-Scope limits:
+---
+
+## Scope limits:
 - Do NOT imply experience with the parent company as a whole if the CV only mentions a subsidiary product.
-- Do NOT imply experience with multiple products unless they are explicitly listed in the CV.
+- Do NOT imply experience with multiple products unless explicitly listed in the CV.
 - Do NOT imply continued usage if the relationship is historical unless timing is explicitly stated.
 
 ---
 
-Integration with relevance scoring:
-- If a clarified relationship increases relevance to the customer:
-  - Move that bullet or skill higher in ordering.
-  - Prefer rewritten bullets that surface the relationship early.
+## Integration with relevance scoring:
+- If a clarified relationship increases relevance:
+  - Move the bullet or skill higher.
+  - Surface the relationship early in rewritten bullets.
 - If the relationship is historical or indirect:
   - Keep the clarification concise and parenthetical.
-  
-  EXTREMELY IMPORTANT:
-  - Return ONLY RAW JSON.
-  - Do NOT include any explanations, comments, or markdown.
-  - Do NOT wrap the JSON in code fences.
-  - Ensure the output is valid JSON that can be parsed without errors.
+
+---
+## 🚨🚨🚨 ABSOLUTELY CRITICAL OUTPUT REQUIREMENTS 🚨🚨🚨
+## FAILURE TO FOLLOW THESE RULES INVALIDATES THE ENTIRE RESPONSE.
+### OUTPUT FORMAT (NON-NEGOTIABLE)
+- You MUST return **ONLY raw JSON**.
+- You MUST NOT include **any explanations, comments, or markdown**.
+- You MUST NOT wrap the JSON in code fences or quotes.
+- The output MUST be **valid, strictly parseable JSON**.
+- The output MUST use **exactly the same schema, structure, and keys** as the input CV JSON.

--- a/cvextract/ml_adjustment/prompts/website_analysis_prompt.md
+++ b/cvextract/ml_adjustment/prompts/website_analysis_prompt.md
@@ -1,6 +1,6 @@
 You are an expert company research and profiling system.
 
-Given the company website URL below, use it as a starting point to gather available public information about the company to fill out the profile. Use your knowledge of publicly available information, business databases, industry trends, and other public sources to research the company.
+Given the company website URL below, use it as a starting point to gather available public information about the company to fill out the profile. Use your knowledge of publicly available information, business databases, industry trends, and other public sources like northdata.de to research the company.
 
 URL:
 {customer_url}
@@ -30,6 +30,7 @@ SEMANTIC GUIDELINES:
 - "rebranded_from" should list previous company names if the company has been rebranded
 - "owned_products" should list concrete products/services the company owns, develops, or sells (not abstract technologies)
 - "used_products" should list concrete products, tools, and platforms the company uses in their tech stack or operations (not abstract technologies)
+- "related_companies" should contain a list of companies that have business relationships, partnerships, or strategic alliances with this company.
 
 JSON SCHEMA:
 {schema}

--- a/tests/test_build_system_prompt.py
+++ b/tests/test_build_system_prompt.py
@@ -346,3 +346,133 @@ class TestBuildSystemPrompt:
         
         assert prompt is not None
         assert "ToolY (Cloud): Hosting" in prompt
+
+    def test_build_system_prompt_with_related_companies(self):
+        """Test related companies in prompt."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": [
+                {
+                    "name": "TechPartner Inc",
+                    "relationship_type": "partner",
+                    "description": "Strategic technology partnership"
+                },
+                {
+                    "name": "DataSupply Corp",
+                    "relationship_type": "supplier",
+                    "description": ""
+                }
+            ]
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        assert "Related Companies & Partnerships" in prompt
+        assert "TechPartner Inc (partner): Strategic technology partnership" in prompt
+        assert "DataSupply Corp (supplier)" in prompt
+
+    def test_build_system_prompt_with_related_companies_missing_fields(self):
+        """Test related companies with missing optional fields."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": [
+                {
+                    "name": "Partner1",
+                    # No relationship_type or description
+                },
+                {
+                    "name": "Partner2",
+                    "relationship_type": "strategic_alliance"
+                    # No description
+                }
+            ]
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        assert "Related Companies & Partnerships" in prompt
+        assert "Partner1" in prompt
+        assert "Partner2 (strategic_alliance)" in prompt
+
+    def test_build_system_prompt_with_related_companies_missing_name(self):
+        """Test related companies with missing name."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": [
+                {
+                    "relationship_type": "investor",
+                    "description": "Venture capital investor"
+                }
+            ]
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        assert "Unknown (investor): Venture capital investor" in prompt
+
+    def test_build_system_prompt_multiple_related_companies(self):
+        """Test multiple related companies are all included."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": [
+                {"name": "Partner1", "relationship_type": "partner"},
+                {"name": "Supplier1", "relationship_type": "supplier"},
+                {"name": "Customer1", "relationship_type": "customer"}
+            ]
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        assert "Partner1" in prompt
+        assert "Supplier1" in prompt
+        assert "Customer1" in prompt
+
+    def test_build_system_prompt_empty_related_companies(self):
+        """Test with empty related_companies list."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": []
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        # Should NOT contain this header since list is empty
+        assert "Related Companies & Partnerships" not in prompt
+
+    def test_build_system_prompt_all_relationship_types(self):
+        """Test all relationship type variations."""
+        research_data = {
+            "name": "Company",
+            "domains": [],
+            "related_companies": [
+                {"name": "Partner", "relationship_type": "partner"},
+                {"name": "Supplier", "relationship_type": "supplier"},
+                {"name": "Customer", "relationship_type": "customer"},
+                {"name": "Investor", "relationship_type": "investor"},
+                {"name": "Sub", "relationship_type": "subsidiary"},
+                {"name": "Parent", "relationship_type": "parent"},
+                {"name": "Alliance", "relationship_type": "strategic_alliance"}
+            ]
+        }
+        
+        prompt = _build_system_prompt(research_data)
+        
+        assert prompt is not None
+        assert "(partner)" in prompt
+        assert "(supplier)" in prompt
+        assert "(customer)" in prompt
+        assert "(investor)" in prompt
+        assert "(subsidiary)" in prompt
+        assert "(parent)" in prompt
+        assert "(strategic_alliance)" in prompt
+

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -49,7 +49,8 @@ class TestFormatPrompt:
             acquisition_text="",
             rebrand_text="",
             owned_products_text="",
-            used_products_text=""
+            used_products_text="",
+            related_companies_text=""
         )
         assert result is not None
         assert "Test Corp" in result


### PR DESCRIPTION
Extends the research data schema to include related companies and their relationships.

This enhances the AI's ability to tailor resume adjustments by considering strategic partnerships and business relationships, allowing for more relevant and context-aware modifications.

Adds tests to cover related companies.