### PR TITLE
Add OpenAI translation adjuster with schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ python -m cvextract.cli \
 - Adjuster-specific parameters (varies by adjuster):
   - For `openai-company-research`: `customer-url=<url>` (required)
   - For `openai-job-specific`: `job-url=<url>` OR `job-description=<text>` (one required)
+  - For `openai-translate`: `language=<target>` (required)
 - `data=<path>` - Input JSON file or directory (only used when NOT chained after extract)
   - When chained after extract, this is ignored and the extracted JSON is used automatically
   - Single file: processes one file
@@ -520,6 +521,19 @@ python -m cvextract.cli \
   --target /output
 ```
 
+#### Translate CV to a Target Language
+
+```bash
+# Translate structured JSON and render with a template
+export OPENAI_API_KEY="sk-proj-..."
+
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=de \
+  --render template=/path/to/template.docx \
+  --target /output
+```
+
 #### Chaining Multiple Adjusters
 
 ```bash
@@ -721,6 +735,11 @@ Use `--list adjusters` to see all available adjusters:
    - Highlights matching experience and skills
    - Adjusts terminology to match job description
    - Parameters: `job-url=<url>` OR `job-description=<text>` (one required)
+
+3. **`openai-translate`** - Translates CV JSON into a target language
+   - Preserves schema, keys, and formatting structure
+   - Keeps names, emails, URLs, tools, and programming languages unchanged
+   - Parameters: `language=<target>` (required)
 
 #### How Adjustment Works
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,48 @@ cvextract already supports reliable CV extraction and adaptation workflows and i
 
 Modern hiring systems reward frequent CV customization, which is time-consuming, emotionally draining, and error-prone. cvextract aims to make CV adaptation a mechanical, repeatable process—so people can focus on opportunities rather than formatting and rewriting.
 
+### Translation module
+
+The `openai-translate` adjuster translates the structured CV JSON into a target language while preserving schema, names, emails, URLs, and technical terms. It accepts language codes or names and keeps the JSON layout stable for rendering.
+
+Examples:
+```bash
+# Hindi
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=hi \
+  --render template=/path/to/template.docx \
+  --target /output
+
+# German
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=de \
+  --render template=/path/to/template.docx \
+  --target /output
+
+# English
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=en \
+  --render template=/path/to/template.docx \
+  --target /output
+
+# Russian
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=ru \
+  --render template=/path/to/template.docx \
+  --target /output
+
+# Ukrainian
+python -m cvextract.cli \
+  --extract source=/path/to/cv.docx \
+  --adjust name=openai-translate language=uk \
+  --render template=/path/to/template.docx \
+  --target /output
+```
+
 ### How it started
 
 This project started as a small, three-day after-hours effort to help a resourcing team migrate consultant CVs from a legacy Word template to a new standardized format. It has since evolved into a standalone playground for experimenting with CV parsing, transformation, and document rendering workflows, and is now published as an open-source project.

--- a/cvextract/adjusters/README.md
+++ b/cvextract/adjusters/README.md
@@ -73,6 +73,36 @@ adjusted_work = adjuster.adjust(
 adjusted_json = adjusted_work.get_step_output(StepName.Adjust)
 ```
 
+### `openai-translate`
+
+Translates CV JSON to a target language while preserving schema and identifiers.
+
+**Parameters:**
+- `language` (required): Target language (ISO code or name)
+
+**Example:**
+```python
+from pathlib import Path
+from cvextract.adjusters import get_adjuster
+from cvextract.cli_config import UserConfig, ExtractStage
+from cvextract.shared import StepName, UnitOfWork
+
+adjuster = get_adjuster("openai-translate", model="gpt-4o-mini")
+work = UnitOfWork(
+    config=UserConfig(target_dir=Path("out"), extract=ExtractStage(source=Path("cv.json"))),
+)
+work.set_step_paths(
+    StepName.Adjust,
+    input_path=Path("cv.json"),
+    output_path=Path("cv.json"),
+)
+adjusted_work = adjuster.adjust(
+    work,
+    language="de"
+)
+adjusted_json = adjusted_work.get_step_output(StepName.Adjust)
+```
+
 ## Creating Custom Adjusters
 
 To create a custom adjuster:
@@ -155,4 +185,5 @@ When creating custom adjusters, follow these testing guidelines:
 3. **Log Appropriately**: Use the logging module to inform users of progress and errors
 4. **Preserve Schema**: Never add or remove fields from the CV data structure
 5. **Defer Output Verification**: Return adjusted CV data and let the pipeline run verifiers after the step completes
+   - The translation adjuster performs a schema validation check before returning.
 6. **Document Parameters**: Clearly document what parameters your adjuster expects

--- a/cvextract/adjusters/__init__.py
+++ b/cvextract/adjusters/__init__.py
@@ -7,6 +7,7 @@ This module provides pluggable and interchangeable CV adjusters with a registry 
 from .base import CVAdjuster
 from .openai_company_research_adjuster import OpenAICompanyResearchAdjuster
 from .openai_job_specific_adjuster import OpenAIJobSpecificAdjuster
+from .openai_translate_adjuster import OpenAITranslateAdjuster
 from .adjuster_registry import (
     register_adjuster,
     get_adjuster,
@@ -17,12 +18,14 @@ from .adjuster_registry import (
 # Register built-in adjusters
 register_adjuster(OpenAICompanyResearchAdjuster)
 register_adjuster(OpenAIJobSpecificAdjuster)
+register_adjuster(OpenAITranslateAdjuster)
 
 
 __all__ = [
     "CVAdjuster",
     "OpenAICompanyResearchAdjuster",
     "OpenAIJobSpecificAdjuster",
+    "OpenAITranslateAdjuster",
     "register_adjuster",
     "get_adjuster",
     "list_adjusters",

--- a/cvextract/adjusters/openai_translate_adjuster.py
+++ b/cvextract/adjusters/openai_translate_adjuster.py
@@ -1,0 +1,395 @@
+"""
+OpenAI-based translation adjuster.
+
+Translates CV JSON to a target language while preserving schema and identifiers.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+try:
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover
+    OpenAI = None  # type: ignore
+
+from ..shared import UnitOfWork, format_prompt, load_input_json, write_output_json
+from .base import CVAdjuster
+from .openai_utils import OpenAIRetry as _OpenAIRetry
+from .openai_utils import RetryConfig as _RetryConfig
+from .openai_utils import extract_json_object as _extract_json_object
+from .openai_utils import get_cached_resource_path
+
+LOG = logging.getLogger("cvextract")
+
+_CV_SCHEMA: Optional[Dict[str, Any]] = None
+_SCHEMA_PATH = get_cached_resource_path("cv_schema.json")
+
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_URL_RE = re.compile(r"\bhttps?://[^\s\"']+\b")
+
+
+def _load_cv_schema() -> Optional[Dict[str, Any]]:
+    """Load the CV schema from file (cached)."""
+    global _CV_SCHEMA
+    if _CV_SCHEMA is not None:
+        return _CV_SCHEMA
+    if not _SCHEMA_PATH:
+        LOG.warning("Failed to load CV schema: schema path not available")
+        return None
+    try:
+        with open(_SCHEMA_PATH, "r", encoding="utf-8") as f:
+            _CV_SCHEMA = json.load(f)
+        return _CV_SCHEMA
+    except Exception as e:
+        LOG.warning("Failed to load CV schema: %s", e)
+        return None
+
+
+def _validate_cv_data(data: Any, schema: Dict[str, Any]) -> List[str]:
+    errs: List[str] = []
+    if not isinstance(data, dict):
+        return ["translated JSON must be an object"]
+
+    required_fields = schema.get("required", [])
+    for field in required_fields:
+        if field not in data:
+            errs.append(f"missing required field: {field}")
+
+    if "identity" in data:
+        identity = data["identity"]
+        identity_props = schema.get("properties", {}).get("identity", {})
+        identity_required = identity_props.get("required", [])
+        for field in identity_required:
+            if not identity or field not in identity:
+                errs.append(f"identity missing required field: {field}")
+            elif not isinstance(identity.get(field), str) or not identity.get(field):
+                errs.append(f"identity.{field} must be a non-empty string")
+
+    if "sidebar" in data:
+        sidebar = data["sidebar"]
+        if sidebar is not None and not isinstance(sidebar, dict):
+            errs.append("sidebar must be an object")
+
+    if "overview" in data:
+        overview = data["overview"]
+        if overview is not None and not isinstance(overview, str):
+            errs.append("overview must be a string")
+
+    if "experiences" in data:
+        experiences = data["experiences"]
+        if not isinstance(experiences, list):
+            errs.append("experiences must be an array")
+        else:
+            for idx, exp in enumerate(experiences):
+                if not isinstance(exp, dict):
+                    errs.append(f"experiences[{idx}] must be an object")
+                    continue
+
+                if "heading" not in exp:
+                    errs.append(f"experiences[{idx}] missing required field: heading")
+                elif not isinstance(exp["heading"], str):
+                    errs.append(f"experiences[{idx}].heading must be a string")
+
+                if "description" not in exp:
+                    errs.append(
+                        f"experiences[{idx}] missing required field: description"
+                    )
+                elif not isinstance(exp["description"], str):
+                    errs.append(f"experiences[{idx}].description must be a string")
+
+                if "bullets" in exp:
+                    if not isinstance(exp["bullets"], list):
+                        errs.append(f"experiences[{idx}].bullets must be an array")
+                    elif exp["bullets"] and not all(
+                        isinstance(b, str) for b in exp["bullets"]
+                    ):
+                        errs.append(f"experiences[{idx}].bullets items must be strings")
+
+                if "environment" in exp:
+                    env = exp["environment"]
+                    if env is not None and not isinstance(env, list):
+                        errs.append(
+                            f"experiences[{idx}].environment must be an array or null"
+                        )
+                    elif (
+                        isinstance(env, list)
+                        and env
+                        and not all(isinstance(e, str) for e in env)
+                    ):
+                        errs.append(
+                            f"experiences[{idx}].environment items must be strings"
+                        )
+
+    return errs
+
+
+def _collect_protected_terms(cv_data: Dict[str, Any]) -> List[str]:
+    terms: List[str] = []
+
+    identity = cv_data.get("identity")
+    if isinstance(identity, dict):
+        for key in ("full_name", "first_name", "last_name"):
+            value = identity.get(key)
+            if isinstance(value, str) and value.strip():
+                terms.append(value.strip())
+
+    sidebar = cv_data.get("sidebar")
+    if isinstance(sidebar, dict):
+        for key in ("languages", "tools"):
+            values = sidebar.get(key)
+            if isinstance(values, list):
+                for value in values:
+                    if isinstance(value, str) and value.strip():
+                        terms.append(value.strip())
+
+    experiences = cv_data.get("experiences")
+    if isinstance(experiences, list):
+        for exp in experiences:
+            if not isinstance(exp, dict):
+                continue
+            env = exp.get("environment")
+            if isinstance(env, list):
+                for value in env:
+                    if isinstance(value, str) and value.strip():
+                        terms.append(value.strip())
+
+    seen = set()
+    deduped = []
+    for term in terms:
+        if term in seen:
+            continue
+        seen.add(term)
+        deduped.append(term)
+    return deduped
+
+
+class _TextProtector:
+    def __init__(self, protected_terms: Iterable[str]) -> None:
+        unique_terms = []
+        seen = set()
+        for term in protected_terms:
+            if not term:
+                continue
+            if term in seen:
+                continue
+            seen.add(term)
+            unique_terms.append(term)
+
+        unique_terms.sort(key=len, reverse=True)
+        self._term_patterns = [
+            re.compile(rf"(?<!\w){re.escape(term)}(?!\w)") for term in unique_terms
+        ]
+        self._replacements: Dict[str, str] = {}
+
+    def protect(self, text: str) -> str:
+        text = _EMAIL_RE.sub(self._replace, text)
+        text = _URL_RE.sub(self._replace, text)
+        for pattern in self._term_patterns:
+            text = pattern.sub(self._replace, text)
+        return text
+
+    def restore(self, text: str) -> str:
+        for token, original in self._replacements.items():
+            text = text.replace(token, original)
+        return text
+
+    def _replace(self, match: re.Match[str]) -> str:
+        token = f"__PROTECTED_{len(self._replacements) + 1}__"
+        self._replacements[token] = match.group(0)
+        return token
+
+
+def _map_strings(value: Any, fn: Callable[[str], str]) -> Any:
+    if isinstance(value, dict):
+        return {key: _map_strings(val, fn) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_map_strings(item, fn) for item in value]
+    if isinstance(value, str):
+        return fn(value)
+    return value
+
+
+def _restore_protected_fields(
+    original: Dict[str, Any], translated: Dict[str, Any]
+) -> Dict[str, Any]:
+    original_identity = original.get("identity")
+    translated_identity = translated.get("identity")
+    if isinstance(original_identity, dict) and isinstance(translated_identity, dict):
+        for key in ("full_name", "first_name", "last_name"):
+            if key in original_identity:
+                translated_identity[key] = original_identity.get(key)
+
+    original_sidebar = original.get("sidebar")
+    translated_sidebar = translated.get("sidebar")
+    if isinstance(original_sidebar, dict) and isinstance(translated_sidebar, dict):
+        for key in ("languages", "tools"):
+            if key in original_sidebar:
+                translated_sidebar[key] = original_sidebar.get(key)
+
+    original_exps = original.get("experiences")
+    translated_exps = translated.get("experiences")
+    if isinstance(original_exps, list) and isinstance(translated_exps, list):
+        for idx, original_exp in enumerate(original_exps):
+            if idx >= len(translated_exps):
+                break
+            translated_exp = translated_exps[idx]
+            if not isinstance(original_exp, dict) or not isinstance(
+                translated_exp, dict
+            ):
+                continue
+            if "environment" in original_exp:
+                translated_exp["environment"] = original_exp.get("environment")
+
+    return translated
+
+
+class OpenAITranslateAdjuster(CVAdjuster):
+    """
+    Adjuster that translates CV JSON into a target language.
+    """
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        api_key: Optional[str] = None,
+        *,
+        retry_config: Optional[_RetryConfig] = None,
+        request_timeout_s: float = 60.0,
+        temperature: float = 0.0,
+        _sleep: Callable[[float], None] = time.sleep,
+    ):
+        self._model = model
+        self._api_key = api_key or os.environ.get("OPENAI_API_KEY")
+        self._retry = retry_config or _RetryConfig()
+        self._request_timeout_s = float(request_timeout_s)
+        self._temperature = float(temperature)
+        self._sleep = _sleep
+
+    def name(self) -> str:
+        return "openai-translate"
+
+    def description(self) -> str:
+        return "Translates CV JSON to a target language using OpenAI"
+
+    def validate_params(self, **kwargs) -> None:
+        language = kwargs.get("language") or kwargs.get("target-language")
+        if language is None or not str(language).strip():
+            raise ValueError(
+                f"Adjuster '{self.name()}' requires non-empty 'language' parameter"
+            )
+
+    def adjust(self, work: UnitOfWork, **kwargs) -> UnitOfWork:
+        cv_data = load_input_json(work)
+        self.validate_params(**kwargs)
+
+        if not self._api_key or OpenAI is None:
+            LOG.warning(
+                "Translate adjust skipped: OpenAI unavailable or API key missing."
+            )
+            return write_output_json(work, cv_data)
+
+        schema = _load_cv_schema()
+        if not schema:
+            LOG.warning("Translate adjust skipped: CV schema unavailable.")
+            return write_output_json(work, cv_data)
+
+        language = str(kwargs.get("language") or kwargs.get("target-language")).strip()
+        protected_terms = _collect_protected_terms(cv_data)
+        system_prompt = format_prompt(
+            "adjuster_prompt_translate_cv",
+            language=language,
+            schema=json.dumps(schema, ensure_ascii=False, indent=2),
+            protected_terms=json.dumps(protected_terms, ensure_ascii=False),
+        )
+        if not system_prompt:
+            LOG.warning("Translate adjust skipped: failed to load prompt template.")
+            return write_output_json(work, cv_data)
+
+        protector = _TextProtector(protected_terms)
+        protected_cv = _map_strings(cv_data, protector.protect)
+
+        user_payload = {
+            "language": language,
+            "original_json": protected_cv,
+            "translated_json": "",
+        }
+
+        temperature = kwargs.get("temperature", self._temperature)
+        try:
+            temperature = float(temperature)
+        except (TypeError, ValueError):
+            LOG.warning("Translate adjust: invalid temperature, using default.")
+            temperature = self._temperature
+
+        client = OpenAI(api_key=self._api_key)
+        retryer = _OpenAIRetry(retry=self._retry, sleep=self._sleep)
+
+        try:
+            completion = retryer.call(
+                lambda: client.chat.completions.create(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {
+                            "role": "user",
+                            "content": json.dumps(user_payload, ensure_ascii=False),
+                        },
+                    ],
+                    temperature=temperature,
+                    timeout=self._request_timeout_s,
+                ),
+                is_write=True,
+                op_name="Translate CV completion",
+            )
+        except Exception as e:
+            LOG.warning(
+                "Translate adjust error (%s); using original JSON.", type(e).__name__
+            )
+            return write_output_json(work, cv_data)
+
+        content = None
+        finish_reason = None
+        try:
+            if completion.choices:
+                choice = completion.choices[0]
+                finish_reason = getattr(choice, "finish_reason", None)
+                content = choice.message.content
+        except Exception:
+            content = None
+            finish_reason = None
+
+        if isinstance(finish_reason, str) and finish_reason != "stop":
+            LOG.warning(
+                "Translate adjust: completion not finished (%s); using original JSON.",
+                finish_reason,
+            )
+            return write_output_json(work, cv_data)
+
+        if not content:
+            LOG.warning("Translate adjust: empty completion; using original JSON.")
+            return write_output_json(work, cv_data)
+
+        translated = _extract_json_object(content)
+        if translated is None:
+            LOG.warning("Translate adjust: invalid JSON response; using original JSON.")
+            return write_output_json(work, cv_data)
+
+        translated = _map_strings(translated, protector.restore)
+        translated = _restore_protected_fields(cv_data, translated)
+
+        errs = _validate_cv_data(translated, schema)
+        if errs:
+            LOG.warning(
+                "Translate adjust: schema validation failed: %s; using original JSON.",
+                "; ".join(errs),
+            )
+            return write_output_json(work, cv_data)
+
+        LOG.info("Translated CV to %s.", language)
+        return write_output_json(work, translated)

--- a/cvextract/adjusters/prompts/adjuster_prompt_translate_cv.md
+++ b/cvextract/adjusters/prompts/adjuster_prompt_translate_cv.md
@@ -1,0 +1,21 @@
+You are a translation engine for structured CV JSON.
+
+Target language: {language}
+
+Translate the content fields in the provided CV JSON to the target language. Keep the JSON schema, keys, and structure exactly the same.
+
+Schema (for reference):
+{schema}
+
+Protected terms (must remain unchanged wherever they appear):
+{protected_terms}
+
+Hard rules:
+- Do NOT add or remove fields or keys.
+- Do NOT change any array ordering or lengths.
+- Do NOT translate names, proper nouns, emails, URLs, technology names, tool names, or programming languages.
+- Do NOT translate items in sidebar.languages, sidebar.tools, or experiences.environment.
+- Preserve any placeholder tokens like __PROTECTED_1__ exactly as-is.
+- Output MUST be raw JSON only (no markdown, no commentary).
+
+Return ONLY the translated JSON object.

--- a/cvextract/cli_gather.py
+++ b/cvextract/cli_gather.py
@@ -152,6 +152,13 @@ Examples:
       --render template=template.docx \\
       --target output/
 
+  Translate a CV and render a template:
+    python -m cvextract.cli \\
+      --extract source=cv.docx \\
+      --adjust name=openai-translate language=de \\
+      --render template=template.docx \\
+      --target output/
+
   Render a template to existing JSON file:
     python -m cvextract.cli \\
       --render template=template.docx data=extracted.json \\

--- a/cvextract/shared.py
+++ b/cvextract/shared.py
@@ -258,7 +258,6 @@ def emit_work_status(work: "UnitOfWork", step: Optional[StepName] = None) -> str
     show_adjust_verify = show_adjust and not (
         config.skip_all_verify or config.adjust.skip_verify
     )
-    show_render_verify = show_render and config.should_compare
 
     segments: List[str] = []
     if show_extract:
@@ -273,7 +272,7 @@ def emit_work_status(work: "UnitOfWork", step: Optional[StepName] = None) -> str
         segments.append(segment)
     if show_render:
         segment = f"R:{icons[StepName.Render]}"
-        if show_render_verify:
+        if show_render:
             segment += f"·{icons[StepName.VerifyRender]}"
         segments.append(segment)
     return f"{'·'.join(segments)} " f"{input_name} | " f"{fmt_issues(work, issue_step)}"

--- a/examples/translation/README.md
+++ b/examples/translation/README.md
@@ -1,0 +1,21 @@
+# Translation Example (German)
+
+This example translates a CV to German using the structured JSON pipeline and renders it with a DOCX template.
+
+## Command
+
+```bash
+export OPENAI_API_KEY="sk-proj-..."
+
+python -m cvextract.cli \
+  --extract source=examples/cvs/Sarah_Connor_CV.docx \
+  --adjust name=openai-translate language=de \
+  --render template=examples/templates/CV_Template_Jinja2.docx \
+  --target output/
+```
+
+## Outputs
+
+- `output/structured_data/Sarah_Connor_CV.json` (extracted)
+- `output/adjusted_structured_data/Sarah_Connor_CV.json` (translated)
+- `output/documents/Sarah_Connor_CV_NEW.docx` (rendered)

--- a/specs/FEATURES.md
+++ b/specs/FEATURES.md
@@ -58,6 +58,7 @@ The adjustment area provides ML-based CV optimization and transformation capabil
 |---------|--------|-------------|--------------|------------|
 | [Company Research Adjuster](areas/adjustment/company-research-adjuster/README.md) | Active | OpenAI-based CV adjustment with company research and caching | `cvextract.adjusters.OpenAICompanyResearchAdjuster` | `OPENAI_API_KEY`, `customer-url=<url>` |
 | [Job-Specific Adjuster](areas/adjustment/job-specific-adjuster/README.md) | Active | Optimizes CV for specific job postings | `cvextract.adjusters.OpenAIJobSpecificAdjuster` | `job-url=<url>` or `job-description=<text>` |
+| [Translate Adjuster](areas/adjustment/openai-translate-adjuster/README.md) | Active | Translates CV JSON into a target language with schema validation | `cvextract.adjusters.OpenAITranslateAdjuster` | `language=<target>` |
 | [Named Adjusters](areas/adjustment/named-adjusters/README.md) | Active | Registry-based adjuster lookup system | `cvextract.adjusters.{register_adjuster, get_adjuster, list_adjusters}` | `--adjust name=<adjuster-name>` |
 | [Adjuster Chaining](areas/adjustment/adjuster-chaining/README.md) | Active | Sequential application of multiple adjusters | Multiple `--adjust` CLI flags | N/A |
 
@@ -155,6 +156,7 @@ The examples area provides sample CVs and documentation for users.
 |---------|--------|-------------|--------------|------------|
 | [Sample CVs](areas/examples/sample-cvs/README.md) | Active | Example CV files for testing and demonstration | `examples/cvs/*.docx` | N/A |
 | [Documentation](areas/examples/documentation/README.md) | Active | Template guides and usage documentation | `examples/templates/TEMPLATE_GUIDE.md` | N/A |
+| [Translation Example](areas/examples/translation-example/README.md) | Active | Translate + render pipeline walkthrough | `examples/translation/README.md` | `OPENAI_API_KEY` |
 
 ---
 

--- a/specs/areas/adjustment/README.md
+++ b/specs/areas/adjustment/README.md
@@ -8,6 +8,7 @@ The adjustment area provides ML-based CV optimization and transformation capabil
 
 - [Company Research Adjuster](company-research-adjuster/README.md) - OpenAI-based adjustment with company research and caching
 - [Job-Specific Adjuster](job-specific-adjuster/README.md) - Optimizes CV for specific job postings
+- [Translate Adjuster](openai-translate-adjuster/README.md) - Translates CV JSON into a target language
 - [Named Adjusters](named-adjusters/README.md) - Registry-based adjuster lookup system
 - [Adjuster Chaining](adjuster-chaining/README.md) - Sequential application of multiple adjusters
 
@@ -28,6 +29,7 @@ The adjustment area provides ML-based CV optimization and transformation capabil
 - **Implementations**:
   - `cvextract/adjusters/openai_company_research_adjuster.py` - Company-based adjustment
   - `cvextract/adjusters/openai_job_specific_adjuster.py` - Job-based adjustment
+  - `cvextract/adjusters/openai_translate_adjuster.py` - Translation adjustment
 
 ### Data Flow
 
@@ -64,5 +66,6 @@ Next Adjuster (if chained)
 - Public API: `cvextract/adjusters/__init__.py`
 - Company Adjuster: `cvextract/adjusters/openai_company_research_adjuster.py`
 - Job Adjuster: `cvextract/adjusters/openai_job_specific_adjuster.py`
+- Translate Adjuster: `cvextract/adjusters/openai_translate_adjuster.py`
 - Prompts: `cvextract/adjusters/prompts/`
 - Documentation: `cvextract/adjusters/README.md`

--- a/specs/areas/adjustment/named-adjusters/README.md
+++ b/specs/areas/adjustment/named-adjusters/README.md
@@ -63,6 +63,7 @@ python -m cvextract.cli \
 
 - **`openai-company-research`**: Company-based CV adjustment
 - **`openai-job-specific`**: Job-based CV adjustment
+- **`openai-translate`**: Translation of CV JSON into a target language
 
 ### Registry Functions
 

--- a/specs/areas/adjustment/openai-translate-adjuster/README.md
+++ b/specs/areas/adjustment/openai-translate-adjuster/README.md
@@ -1,0 +1,133 @@
+# Translate Adjuster
+
+## Overview
+
+The translate adjuster converts structured CV JSON into a target language while preserving schema, identifiers, and formatting structure.
+
+## Status
+
+**Active** - Fully implemented
+
+## Description
+
+The `OpenAITranslateAdjuster` class:
+1. Accepts a target language (ISO code or name)
+2. Translates content fields while preserving schema and keys
+3. Preserves names, emails, URLs, tools, and programming languages
+4. Keeps list structures and ordering intact
+5. Validates translated output against the CV schema before returning
+
+## Entry Points
+
+### Programmatic API
+
+```python
+from pathlib import Path
+from cvextract.adjusters import get_adjuster
+from cvextract.cli_config import UserConfig, ExtractStage
+from cvextract.shared import StepName, UnitOfWork
+
+adjuster = get_adjuster("openai-translate", model="gpt-4o-mini")
+work = UnitOfWork(
+    config=UserConfig(target_dir=Path("out"), extract=ExtractStage(source=Path("cv.json"))),
+)
+work.set_step_paths(
+    StepName.Adjust,
+    input_path=Path("cv.json"),
+    output_path=Path("cv_translated.json"),
+)
+adjusted_cv = adjuster.adjust(
+    work,
+    language="de"
+)
+```
+
+### CLI Usage
+
+```bash
+export OPENAI_API_KEY="sk-proj-..."
+
+python -m cvextract.cli \
+  --extract source=cv.docx \
+  --adjust name=openai-translate language=de \
+  --render template=template.docx \
+  --target output/
+```
+
+## Configuration
+
+### Parameters
+
+- **`language`** (required): Target language (ISO code or descriptive name)
+- **`openai-model`** (optional): OpenAI model name, defaults to `gpt-4o-mini`
+- **`temperature`** (optional): OpenAI temperature (default `0.0` for deterministic output)
+
+### Environment Variables
+
+- **`OPENAI_API_KEY`** (required): OpenAI API key
+- **`OPENAI_MODEL`** (optional): Default model name
+
+## Interfaces
+
+### Input
+
+- CV JSON data conforming to `cv_schema.json`
+
+### Output
+
+- Translated CV JSON with preserved schema and identifiers
+
+## Dependencies
+
+### Internal Dependencies
+
+- `cvextract.adjusters.base.CVAdjuster` - Base class
+- `cvextract.shared.format_prompt` - Prompt formatting
+- `cvextract.contracts.cv_schema.json` - CV schema for validation
+- `cvextract.adjusters.openai_utils` - Retry/backoff and schema access helpers
+
+### External Dependencies
+
+- `openai` (>= 1.0) - OpenAI API client
+
+### Integration Points
+
+- Registered as `"openai-translate"` in `cvextract/adjusters/__init__.py`
+- Used by `cvextract.cli_execute_adjust.execute()` when `--adjust name=openai-translate`
+- Can be chained with other adjusters
+
+## Test Coverage
+
+Tested in:
+- `tests/test_translate_adjuster.py`
+  - Golden fixture translation to a target language
+  - Schema validation failure fallback
+- `tests/test_adjusters.py` - Registry and list coverage
+- `tests/test_cli_gather.py` - CLI list output
+
+## Implementation History
+
+The translate adjuster was added to enable multi-language CV workflows while keeping JSON structure stable for template rendering.
+
+**Key Files**:
+- `cvextract/adjusters/openai_translate_adjuster.py` - Implementation
+- `cvextract/adjusters/prompts/adjuster_prompt_translate_cv.md` - Translation prompt
+
+## Open Questions
+
+1. **Glossary Support**: Should a user-provided glossary be supported for strict term preservation?
+2. **Date/Unit Localization**: Should localized date formats and units be supported in a future version?
+
+## File Paths
+
+- Implementation: `cvextract/adjusters/openai_translate_adjuster.py`
+- Prompt: `cvextract/adjusters/prompts/adjuster_prompt_translate_cv.md`
+- Tests: `tests/test_translate_adjuster.py`
+- Documentation: `cvextract/adjusters/README.md`
+
+## Related Documentation
+
+- [Adjustment Architecture](../README.md)
+- [Named Adjusters](../named-adjusters/README.md)
+- [Adjuster Chaining](../adjuster-chaining/README.md)
+- Module README: `cvextract/adjusters/README.md`

--- a/specs/areas/cli/named-flags/README.md
+++ b/specs/areas/cli/named-flags/README.md
@@ -72,6 +72,7 @@ python -m cvextract.cli \
 - `customer-url=<url>` - For company research
 - `job-url=<url>` - For job-specific
 - `job-description=<text>` - For job-specific
+- `language=<target>` - For translation
 - `openai-model=<model>` - OpenAI model override
 
 **Apply**:
@@ -152,6 +153,7 @@ Named flags replaced earlier positional argument syntax to improve clarity and m
 # Multiple parameters
 --extract source=cv.docx name=openai-extractor output=data.json
 --adjust name=openai-job-specific job-url=https://example.com/job/123 openai-model=gpt-4
+--adjust name=openai-translate language=de openai-model=gpt-4o-mini
 ```
 
 ### Boolean Flags

--- a/specs/areas/examples/README.md
+++ b/specs/areas/examples/README.md
@@ -8,6 +8,7 @@ The examples area provides sample CVs and documentation to help users understand
 
 - [Sample CVs](sample-cvs/README.md) - Example CV files for testing and demonstration
 - [Documentation](documentation/README.md) - Template guides and usage documentation
+- [Translation Example](translation-example/README.md) - Example of translate + render pipeline
 
 ## Architectural Notes
 
@@ -23,6 +24,7 @@ The examples area provides sample CVs and documentation to help users understand
 - **Sample CVs**: `examples/cvs/*.docx` - Ready-to-use example CVs
 - **Template Guide**: `examples/templates/TEMPLATE_GUIDE.md` - Complete templating documentation
 - **Templates**: `examples/templates/*.docx` - Sample templates
+- **Translation Example**: `examples/translation/README.md` - Translate + render walkthrough
 
 ### Integration Points
 
@@ -40,3 +42,4 @@ The examples area provides sample CVs and documentation to help users understand
 - Sample CVs: `examples/cvs/*.docx`
 - Templates: `examples/templates/*.docx`
 - Template Guide: `examples/templates/TEMPLATE_GUIDE.md`
+- Translation Example: `examples/translation/README.md`

--- a/specs/areas/examples/documentation/README.md
+++ b/specs/areas/examples/documentation/README.md
@@ -13,7 +13,8 @@ The documentation feature provides comprehensive guides and reference materials 
 Included documentation:
 1. **TEMPLATE_GUIDE.md**: Complete guide to creating and using CV templates
 2. **Main README.md**: Comprehensive project documentation with examples
-3. **Module READMEs**: Documentation in each module directory
+3. **Translation Example**: End-to-end translate + render walkthrough
+4. **Module READMEs**: Documentation in each module directory
 
 Features:
 - Step-by-step guides
@@ -134,6 +135,7 @@ Documentation has evolved alongside the project:
 
 **Key Files**:
 - `examples/templates/TEMPLATE_GUIDE.md`
+- `examples/translation/README.md`
 - `README.md`
 - `cvextract/*/README.md` (module docs)
 
@@ -202,6 +204,7 @@ cv_data = json.loads(output_path.read_text(encoding="utf-8"))
 ## File Paths
 
 - Template Guide: `examples/templates/TEMPLATE_GUIDE.md`
+- Translation Example: `examples/translation/README.md`
 - Main README: `README.md`
 - Module READMEs: `cvextract/*/README.md`
 - Contributing: `.github/CONTRIBUTING.md`

--- a/specs/areas/examples/translation-example/README.md
+++ b/specs/areas/examples/translation-example/README.md
@@ -1,0 +1,39 @@
+# Translation Example
+
+## Overview
+
+The translation example demonstrates how to translate extracted CV JSON into a target language and render a DOCX template.
+
+## Status
+
+**Active** - Example documentation
+
+## Description
+
+The example shows a full pipeline:
+1. Extract from a DOCX CV
+2. Translate structured JSON using the `openai-translate` adjuster
+3. Render with an existing DOCX template
+
+## Entry Points
+
+### Example File
+
+- `examples/translation/README.md`
+
+## Dependencies
+
+- Requires `OPENAI_API_KEY` for the translation adjuster
+- Uses sample CVs from `examples/cvs/`
+- Uses templates from `examples/templates/`
+
+## File References
+
+- Example: `examples/translation/README.md`
+- Sample CVs: `examples/cvs/*.docx`
+- Templates: `examples/templates/*.docx`
+
+## Related Documentation
+
+- [Examples Area](../README.md)
+- [Translate Adjuster](../../adjustment/openai-translate-adjuster/README.md)

--- a/specs/feature-requests/openai-translate-adjuster.md
+++ b/specs/feature-requests/openai-translate-adjuster.md
@@ -1,0 +1,121 @@
+# Feature Request
+
+> **This document MUST result in a tracked issue.**  
+> When completed, **always create or update a project issue** that links to this feature request and reflects its current state.
+
+## Title
+Add an adjuster to translate CV JSON into an arbitrary target language (LLM-backed)
+
+## Description
+Add a new adjuster that translates an extracted CV (structured JSON conforming to the cvextract schema) into an arbitrary target language, producing schema-valid translated JSON that can then be rendered with an existing DOCX template.
+
+The feature should integrate into the existing composable CLI pipeline (Extract -> Adjust -> Render). The new adjuster will:
+- Take `language=<target>` (e.g., `de`, `fr`, `es`, or "German", "French") as a required parameter.
+- Translate only content fields, while preserving:
+  - JSON schema structure and keys
+  - formatting-relevant structural elements (lists, bullet arrays, etc.)
+  - non-translatable identifiers (names, emails, URLs)
+- Never Translate (this is crucial)
+  - Technology names
+  - Tool's Names
+  - Programming Languages
+
+The adjuster should be deterministic by default (temperature 0), and validate output against the CV schema before returning.
+
+CLI example:
+```
+python -m cvextract.cli \
+  --extract name=openai-extractor source=/path/to/cv.docx \
+  --adjust name=openai-translate language=de \
+  --render template=./examples/templates/CV_Template_Jinja2.docx \
+  --target /tmp/out
+```
+
+## Motivation
+- CVs often need to be submitted in a customer's/local language, not only tailored by role.
+- Translating the structured representation keeps the workflow mechanical and repeatable (avoids editing Word docs manually).
+- Benefits:
+  - End users: quick translation without reformatting
+  - Resourcing teams: translate many CVs consistently across languages/templates
+  - Developers: translation becomes a reusable pipeline component (adjuster)
+
+User stories:
+- As a job seeker, I want to translate my CV to German while keeping the same template layout.
+- As a staffing/resourcing team member, I want to batch translate multiple consultants' CV JSON to French and render them using a French DOCX template.
+- As a developer, I want a pluggable adjuster so I can swap translation providers later.
+
+## Must Have
+- New adjuster: `openai-translate` appears in `--list adjusters`.
+- Requires `language` parameter.
+- Produces output that:
+  - validates against the existing CV JSON schema
+  - preserves schema structure and required fields
+  - does not translate emails/URLs unless configured
+- Deterministic defaults (e.g. temperature 0) and explicit model configuration.
+- Clear error messages when translation fails or schema validation fails.
+- No verification with the roundtrip verifier should happen
+- Tests:
+  - at least one "golden" fixture translating a small CV JSON to one target language
+  - schema validation test for translated output
+- Documentation updates:
+  - README / CLI help shows how to translate and render with templates
+  - specs updated to reflect new adjuster and parameters
+
+## Should Have
+- Language normalization:
+  - accept ISO codes and names (e.g., `de`, `de-DE`, `German`)
+  - This should be handled by the LLM, so it should be possible to give the language in any format.
+
+## Should Not Have / Out of Scope
+- Translating the DOCX file directly (translation happens on JSON, not on rendered documents).
+- Automatic selection of language based on CV content.
+- Fully offline translation (first implementation may require an API).
+- Perfect localization of formatting conventions (dates/units) beyond basic translation.
+
+## Alternatives Considered
+- Translate after rendering DOCX:
+  - rejected because it breaks determinism and makes layout/template fragile.
+- External translation libraries (argos-translate, Marian, etc.):
+  - rejected for v1 due to quality variance and added packaging complexity; could be a future provider.
+- Manual translation in templates:
+  - rejected because it pushes effort back to the user and doesn't scale.
+
+## Risks & Trade-offs
+- Hallucination / meaning drift in LLM translation:
+  - mitigate with deterministic settings, glossary support, and schema validation.
+- Proper nouns and company/product names may be incorrectly translated:
+  - mitigate with "preserve proper nouns" default and glossary.
+- Cost and rate limits for API-backed translation:
+  - document clearly; allow users to choose model; enable batch/concurrency controls.
+- Some fields may be ambiguous (short bullet points):
+  - accept and rely on glossary and optional per-field translation controls.
+
+## Success Criteria
+- A user can run a single pipeline command that outputs a rendered DOCX in the target language using their chosen template.
+- Translated JSON always validates against schema for standard fixtures.
+- Minimal "surprise translations" (emails/URLs unchanged; proper nouns preserved by default).
+- Add at least one real-world example in `examples/` that demonstrates translation + render.
+
+## Additional Context / Mockups
+- Example command:
+  ```
+  python -m cvextract.cli --extract source=/path/to/cv.docx --adjust name=openai-translate language=de --render template=/path/to/template.docx --target /output
+  ```
+- Expected pipeline artifact:
+  - extracted.json (source language)
+  - translated.json (target language)
+  - rendered.docx (target language template)
+  - no verification with the roundtrip verifier should happen
+
+## Implementation Checklist (**Always Required**)
+- [x] **Create or update a tracked issue for this feature**
+- [x] Ensure the issue references this document and stays in sync
+- [x] Add new tests if applicable
+- [x] Extend existing tests if applicable
+- [ ] Remove stale or unused tests and code
+- [x] Identify and remove unused imports/usings/includes
+- [ ] Run linters, analyzers, and formatters
+- [x] **Update existing feature specification files under `specs/` to reflect this feature**
+- [x] **Amend the relevant `specs/` files whenever requirements change during implementation**
+- [x] Update README, help messages, and relevant documentation
+- [ ] Ensure Codecov checks pass; if coverage drops, make a best effort to improve it

--- a/specs/issues/ISSUE-0001-openai-translate-adjuster.md
+++ b/specs/issues/ISSUE-0001-openai-translate-adjuster.md
@@ -1,0 +1,31 @@
+# ISSUE-0001: OpenAI Translate Adjuster
+
+## Status
+
+- State: Implemented
+- Owner: Unassigned
+- Feature Request: `specs/feature-requests/openai-translate-adjuster.md`
+- Specification: `specs/areas/adjustment/openai-translate-adjuster/README.md`
+
+## Summary
+
+Implement a translation adjuster that converts CV JSON into a target language while preserving schema structure, identifiers, and non-translatable terms. The adjuster integrates into the Extract -> Adjust -> Render pipeline and validates translated output before returning.
+
+## Scope
+
+- Add `openai-translate` adjuster and register in registry
+- Translate content fields with deterministic defaults
+- Preserve names, emails, URLs, tools, and programming languages
+- Validate translated output against `cv_schema.json`
+- Add tests and documentation
+
+## Milestones
+
+- [x] Implement adjuster and prompt
+- [x] Register adjuster for `--list adjusters`
+- [x] Add examples and documentation
+- [x] Add translation tests and schema validation test
+
+## Notes
+
+- Keep this issue in sync with `specs/feature-requests/openai-translate-adjuster.md`.

--- a/tests/fixtures/translate_expected_de.json
+++ b/tests/fixtures/translate_expected_de.json
@@ -1,0 +1,28 @@
+{
+  "identity": {
+    "title": "Softwareingenieur",
+    "full_name": "Ada Lovelace",
+    "first_name": "Ada",
+    "last_name": "Lovelace"
+  },
+  "sidebar": {
+    "languages": ["Python", "C++"],
+    "tools": ["Docker", "Kubernetes"],
+    "certifications": ["AWS Certified Developer"],
+    "industries": ["Finanzen"],
+    "spoken_languages": ["Englisch"],
+    "academic_background": ["BSc Informatik"]
+  },
+  "overview": "Erfahrener Ingenieur mit Fokus auf Datenpipelines.",
+  "experiences": [
+    {
+      "heading": "Jan 2020 - Heute | Senior-Ingenieur bei Acme Corp",
+      "description": "Entwickelte skalierbare Services fur Analysen.",
+      "bullets": [
+        "Leitete ein Team von 5 Ingenieuren.",
+        "Reduzierte die Latenz um 30%."
+      ],
+      "environment": ["Python", "PostgreSQL"]
+    }
+  ]
+}

--- a/tests/fixtures/translate_input.json
+++ b/tests/fixtures/translate_input.json
@@ -1,0 +1,28 @@
+{
+  "identity": {
+    "title": "Software Engineer",
+    "full_name": "Ada Lovelace",
+    "first_name": "Ada",
+    "last_name": "Lovelace"
+  },
+  "sidebar": {
+    "languages": ["Python", "C++"],
+    "tools": ["Docker", "Kubernetes"],
+    "certifications": ["AWS Certified Developer"],
+    "industries": ["Finance"],
+    "spoken_languages": ["English"],
+    "academic_background": ["BSc Computer Science"]
+  },
+  "overview": "Experienced engineer focused on data pipelines.",
+  "experiences": [
+    {
+      "heading": "Jan 2020 - Present | Senior Engineer at Acme Corp",
+      "description": "Built scalable services for analytics.",
+      "bullets": [
+        "Led a team of 5 engineers.",
+        "Reduced latency by 30%."
+      ],
+      "environment": ["Python", "PostgreSQL"]
+    }
+  ]
+}

--- a/tests/test_adjusters.py
+++ b/tests/test_adjusters.py
@@ -247,10 +247,11 @@ class TestAdjusterRegistry:
     def test_list_adjusters_returns_builtin_adjusters(self):
         """list_adjusters should return all registered adjusters."""
         adjusters = list_adjusters()
-        assert len(adjusters) >= 2
+        assert len(adjusters) >= 3
         adjuster_names = [a["name"] for a in adjusters]
         assert "openai-company-research" in adjuster_names
         assert "openai-job-specific" in adjuster_names
+        assert "openai-translate" in adjuster_names
 
     def test_get_adjuster_returns_instance(self):
         """get_adjuster should return an instance of the requested adjuster."""
@@ -1928,6 +1929,7 @@ class TestCLIListAdjusters:
 
         assert "openai-company-research" in captured.out
         assert "openai-job-specific" in captured.out
+        assert "openai-translate" in captured.out
         assert "Available Adjusters" in captured.out
 
 

--- a/tests/test_cli_execute_parallel.py
+++ b/tests/test_cli_execute_parallel.py
@@ -343,6 +343,19 @@ class TestExecuteParallelPipeline:
 class TestScanDirectoryForFiles:
     """Tests for scan_directory_for_files function - new generic version."""
 
+    def test_scan_directory_missing_path_raises(self, tmp_path: Path):
+        """Missing directory should raise FileNotFoundError."""
+        missing_dir = tmp_path / "missing"
+        with pytest.raises(FileNotFoundError, match="Directory not found"):
+            scan_directory_for_files(missing_dir, "*.docx")
+
+    def test_scan_directory_file_path_raises(self, tmp_path: Path):
+        """Non-directory path should raise ValueError."""
+        file_path = tmp_path / "not_a_dir.txt"
+        file_path.write_text("not a directory", encoding="utf-8")
+        with pytest.raises(ValueError, match="Path is not a directory"):
+            scan_directory_for_files(file_path, "*.docx")
+
     def test_scan_directory_for_docx_files(self, test_directory: Path):
         """Test scanning directory for .docx files using generic function."""
         from cvextract.cli_execute_parallel import scan_directory_for_files

--- a/tests/test_cli_gather.py
+++ b/tests/test_cli_gather.py
@@ -18,6 +18,7 @@ class TestHandleListCommand:
         assert "Available Adjusters" in captured.out
         assert "openai-company-research" in captured.out
         assert "openai-job-specific" in captured.out
+        assert "openai-translate" in captured.out
 
     def test_list_renderers(self, capsys):
         """--list renderers should print available renderers."""

--- a/tests/test_prompt_packaging.py
+++ b/tests/test_prompt_packaging.py
@@ -51,6 +51,7 @@ class TestPromptPackaging:
         adjuster_expected_prompts = [
             "adjuster_promp_for_a_company.md",
             "adjuster_promp_for_specific_job.md",
+            "adjuster_prompt_translate_cv.md",
             "website_analysis_prompt.md",
         ]
 
@@ -74,6 +75,7 @@ class TestPromptPackaging:
         prompts_to_test = [
             "website_analysis_prompt",
             "adjuster_promp_for_specific_job",
+            "adjuster_prompt_translate_cv",
             "cv_extraction_system",
             "cv_extraction_user",
         ]

--- a/tests/test_translate_adjuster.py
+++ b/tests/test_translate_adjuster.py
@@ -42,6 +42,17 @@ def _mock_openai(monkeypatch, response_content: str) -> MagicMock:
     return mock_client
 
 
+def _mock_openai_with_completion(monkeypatch, completion: object) -> MagicMock:
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = completion
+
+    mock_openai = MagicMock(return_value=mock_client)
+    monkeypatch.setattr(translate_module, "OpenAI", mock_openai)
+    return mock_client
+
+
 def test_translate_adjuster_golden_fixture(tmp_path: Path, monkeypatch):
     cv_data = _load_fixture("translate_input.json")
     expected = _load_fixture("translate_expected_de.json")
@@ -67,6 +78,201 @@ def test_translate_adjuster_schema_failure_returns_original(
     cv_data = _load_fixture("translate_input.json")
     bad_output = {"overview": "Oops", "experiences": []}
     _mock_openai(monkeypatch, json.dumps(bad_output, ensure_ascii=False))
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_invalid_temperature_uses_default(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+    expected = _load_fixture("translate_expected_de.json")
+
+    mock_client = _mock_openai(monkeypatch, json.dumps(expected, ensure_ascii=False))
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de", temperature="bad")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == expected
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["temperature"] == 0.0
+
+
+def test_translate_adjuster_finish_reason_not_stop_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+    expected = _load_fixture("translate_expected_de.json")
+
+    completion = MagicMock()
+    completion.choices = [
+        MagicMock(
+            message=MagicMock(content=json.dumps(expected, ensure_ascii=False)),
+            finish_reason="length",
+        )
+    ]
+    _mock_openai_with_completion(monkeypatch, completion)
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_empty_completion_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    completion = MagicMock()
+    completion.choices = [
+        MagicMock(message=MagicMock(content=""), finish_reason="stop")
+    ]
+    _mock_openai_with_completion(monkeypatch, completion)
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_invalid_json_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    completion = MagicMock()
+    completion.choices = [
+        MagicMock(message=MagicMock(content="not-json"), finish_reason="stop")
+    ]
+    _mock_openai_with_completion(monkeypatch, completion)
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_completion_choices_error_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    class ExplodingCompletion:
+        @property
+        def choices(self):
+            raise RuntimeError("boom")
+
+    cv_data = _load_fixture("translate_input.json")
+    _mock_openai_with_completion(monkeypatch, ExplodingCompletion())
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_openai_error_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    class ExplodingRetry:
+        def __init__(self, **_kwargs):
+            pass
+
+        def call(self, _fn, **_kwargs):
+            raise RuntimeError("boom")
+
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    monkeypatch.setattr(translate_module, "_OpenAIRetry", ExplodingRetry)
+    monkeypatch.setattr(translate_module, "OpenAI", MagicMock())
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_missing_api_key_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    monkeypatch.setattr(translate_module, "OpenAI", MagicMock())
+
+    adjuster = OpenAITranslateAdjuster(api_key=None)
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_schema_unavailable_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    monkeypatch.setattr(translate_module, "_load_cv_schema", lambda: None)
+    monkeypatch.setattr(translate_module, "OpenAI", MagicMock())
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data
+
+
+def test_translate_adjuster_prompt_missing_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    monkeypatch.setattr(translate_module, "format_prompt", lambda *args, **kwargs: None)
+    monkeypatch.setattr(translate_module, "OpenAI", MagicMock())
 
     adjuster = OpenAITranslateAdjuster(api_key="test-key")
     work = _make_work(tmp_path, cv_data)

--- a/tests/test_translate_adjuster.py
+++ b/tests/test_translate_adjuster.py
@@ -1,0 +1,78 @@
+"""Tests for the OpenAI translate adjuster."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from cvextract.adjusters.openai_translate_adjuster import OpenAITranslateAdjuster
+from cvextract.cli_config import ExtractStage, UserConfig
+from cvextract.shared import StepName, UnitOfWork
+
+
+def _load_fixture(name: str) -> dict:
+    fixture_path = Path(__file__).parent / "fixtures" / name
+    return json.loads(fixture_path.read_text(encoding="utf-8"))
+
+
+def _make_work(tmp_path: Path, cv_data: dict) -> UnitOfWork:
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "output.json"
+    input_path.write_text(json.dumps(cv_data, indent=2), encoding="utf-8")
+    work = UnitOfWork(
+        config=UserConfig(target_dir=tmp_path, extract=ExtractStage(source=input_path)),
+        initial_input=input_path,
+    )
+    work.set_step_paths(StepName.Adjust, input_path=input_path, output_path=output_path)
+    return work
+
+
+def _mock_openai(monkeypatch, response_content: str) -> MagicMock:
+    import cvextract.adjusters.openai_translate_adjuster as translate_module
+
+    mock_completion = MagicMock()
+    mock_completion.choices = [
+        MagicMock(message=MagicMock(content=response_content), finish_reason="stop")
+    ]
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_completion
+
+    mock_openai = MagicMock(return_value=mock_client)
+    monkeypatch.setattr(translate_module, "OpenAI", mock_openai)
+    return mock_client
+
+
+def test_translate_adjuster_golden_fixture(tmp_path: Path, monkeypatch):
+    cv_data = _load_fixture("translate_input.json")
+    expected = _load_fixture("translate_expected_de.json")
+
+    mock_client = _mock_openai(monkeypatch, json.dumps(expected, ensure_ascii=False))
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == expected
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["temperature"] == 0.0
+
+
+def test_translate_adjuster_schema_failure_returns_original(
+    tmp_path: Path, monkeypatch
+):
+    cv_data = _load_fixture("translate_input.json")
+    bad_output = {"overview": "Oops", "experiences": []}
+    _mock_openai(monkeypatch, json.dumps(bad_output, ensure_ascii=False))
+
+    adjuster = OpenAITranslateAdjuster(api_key="test-key")
+    work = _make_work(tmp_path, cv_data)
+    result = adjuster.adjust(work, language="de")
+
+    output_path = result.get_step_output(StepName.Adjust)
+    assert output_path is not None
+    output = json.loads(output_path.read_text(encoding="utf-8"))
+    assert output == cv_data


### PR DESCRIPTION
- Added `OpenAITranslateAdjuster` with deterministic defaults, schema validation, protected-term handling, and safe fallbacks on API/prompt/schema errors.
- Added translation prompt template and ensured prompt packaging coverage.
- Registered `openai-translate` in the adjuster registry and updated module docs.
- Extended CLI help/examples and README with a dedicated Translation module section and multi-language usage examples (hi, de, en, ru, uk).
- Added translation example docs under `examples/translation/README.md` plus related specs.
- Updated specs index and adjustment/CLI/example area docs to include the new adjuster and parameters.
- Created feature request and tracked issue docs for the translation adjuster.
- Added fixtures and tests for translation golden output and validation fallbacks.
- Expanded tests to cover OpenAI errors, invalid completions, missing params, schema loading failures, and validator edge cases.